### PR TITLE
Fix Typo in PaymentMeans serialization

### DIFF
--- a/src/PaymentMeans.php
+++ b/src/PaymentMeans.php
@@ -85,12 +85,12 @@ class PaymentMeans implements XmlSerializable
     function xmlSerialize(Writer $writer)
     {
         $writer->write([
-            Schema::CBC . 'PaymmentMeansCode' => $this->code,
+            Schema::CBC . 'PaymentMeansCode' => $this->code,
         ]);
 
         if (!empty($this->dueDate)) {
             $writer->write([
-                Schema::CBC . 'PaymmentMeansDueDate' => $this->dueDate->format('Y-m-d'),
+                Schema::CBC . 'PaymentMeansDueDate' => $this->dueDate->format('Y-m-d'),
             ]);
         }
 

--- a/src/PaymentMeans.php
+++ b/src/PaymentMeans.php
@@ -90,7 +90,7 @@ class PaymentMeans implements XmlSerializable
 
         if (!empty($this->dueDate)) {
             $writer->write([
-                Schema::CBC . 'PaymentMeansDueDate' => $this->dueDate->format('Y-m-d'),
+                Schema::CBC . 'PaymentDueDate' => $this->dueDate->format('Y-m-d'),
             ]);
         }
 


### PR DESCRIPTION
When using `PaymentMeans` the xml has a typo resulting in invalid UBL.